### PR TITLE
gateway 도커내부로 옮겨서 테스트 현재 오류있음

### DIFF
--- a/commerce/src/main/java/com/every/commerce/controller/MemberController.java
+++ b/commerce/src/main/java/com/every/commerce/controller/MemberController.java
@@ -1,6 +1,5 @@
 package com.every.commerce.controller;
 
-
 import com.every.commerce.dto.UserDTO;
 import com.every.commerce.service.MemberService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,9 +8,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.lang.reflect.InvocationTargetException;
-
 
 @Controller
 @RequestMapping("/member-service")
@@ -54,10 +53,5 @@ public class MemberController {
 
 		return id;
 	}
-	@GetMapping("/api/v1/test")
-	public void test(){
-		System.out.println("test");
-	}
-
 
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       context: .
       dockerfile: ./product/Dockerfile
     ports:
-      - "6000:9091"
+      - "9091:9091"
     environment:
       SPRING_DATASOURCE_URL: jdbc:mysql://mysql_db:3306/users_db?useSSL=false&allowPublicKeyRetrieval=true
       SPRING_DATASOURCE_USERNAME: "root"
@@ -63,7 +63,7 @@ services:
       context: .
       dockerfile: ./order/Dockerfile
     ports:
-      - "7000:9092"
+      - "9092:9092"
     environment:
       SPRING_DATASOURCE_URL: jdbc:mysql://mysql_db:3306/users_db?useSSL=false&allowPublicKeyRetrieval=true
       SPRING_DATASOURCE_USERNAME: "root"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,4 +79,11 @@ services:
     depends_on:
       - member
       - member2
+  apigateway:
+    container_name: gateway
+    ports:
+    - "9002:9001"
+    build:
+      context: .
+      dockerfile: ./gateway/Dockerfile
 

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,0 +1,6 @@
+FROM openjdk:11-jre as build
+COPY .. /
+FROM eclipse-temurin:11-jre
+ARG MODULE_NAME=gateway
+COPY --from=build ${MODULE_NAME}/build/libs/*.jar  app.jar
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
     gateway:
       routes:
         - id: member-service
-          uri: http://localhost:90/
+          uri: http://member-service:90/
           predicates:
             - Path=/member-service/**
         - id: product-service

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -7,15 +7,15 @@ spring:
     gateway:
       routes:
         - id: member-service
-          uri: http://member-service:90/
+          uri: http://nginx-member:90/
           predicates:
             - Path=/member-service/**
         - id: product-service
-          uri: http://localhost:70/
+          uri: http://product:9091/
           predicates:
             - Path=/product-service/**
         - id: order-service
-          uri: http://localhost:7000/
+          uri: http://order:9092/
           predicates:
             - Path=/order-service/**
 server:


### PR DESCRIPTION
새로운 브런치를 생성했습니다! 이렇게 하면 되는게 맞을까요?  질문은 전과 동일합니다! 


현재 orderservice를 올리고 gateway에 올리며 테스트를 하려는 와중에 기존에 user-service (nginx 포트번호로 지정한 90번)
과 gateway가 연결이 안된다는걸 알게되었습니다,
제기억에 전에 테스트했을때는 되어서 넘어갔던걸로 기억나는데,
gateway 서버 포트번호인 locahost:9001 에 userservice 연결포트인 member-service 를 합친
localhost:9001://member-service 로 진입했을때, home이 연결이 안됩니다.

그래서 docker 네트워크로 열었는데 연결지점은 uri: http://localhost/: 으로 로컬 포트로 열어서 문제가 된걸까 하여 도커컴포즈에 gateway를 넣어서 테스트를 돌리고 있었습니다.

혹시 도커내부 uri를 사용해야하나 하고일단 첫번째로 uri: http://member-service:90/ 로 localhost대신 member-service (도커컴포즈 container-name 을 넣어보면 어떨까 추가하였습니다. 이것도 실패하였습니다.

local에서 gateway를 띄우고 docker에서 띄운 user-service와의 연동은 안되는게 맞는것인지 멘토님 컴퓨터에서는 되는데 제가 테스트를 잘못한것인지
해결방법은 어떤게 있을지 (도커 내부 네트워크 포트번호를 심어보는 방안은 pr 올리면서 시도해보겠습니다)
여쭙습니다!
그리고 추가적으로 pr 코드를 조금 깔끔하게 하기위해서 새로 feature 브랜치를 따서 gateway문제만 첫번째 커밋으로 올린것인 데, 밑에 딸려있는 pr은 원래 나오는것이 맞는것인지도 여줍습니다